### PR TITLE
docs: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report a bug
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## What happened?
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behavior
+
+## Environment
+- OS:
+- Java version:
+- Branch/commit:
+
+## Logs / screenshots

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,15 @@
+---
+name: Task
+about: A development task
+title: "[Task] "
+labels: enhancement
+assignees: ""
+---
+
+## Goal
+
+## Acceptance criteria
+- [ ]
+- [ ]
+
+## Notes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+<!-- What is this PR about? -->
+
+## Changes
+- 
+
+## How to test
+- [ ] mvn clean test
+- [ ] (Optional) Run Main / manual check
+
+## Notes
+<!-- Anything reviewers should pay attention to -->
+-


### PR DESCRIPTION
Adds GitHub templates:
- PR template (summary / how to test / notes)
- Issue templates: Bug report + Task

Keeps PRs/issues consistent and makes reviews faster (no more missing test steps / repro steps).

No code changes.