### PR TITLE
ci: add GitHub Actions workflow for Maven tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Run tests
+        run: mvn -q clean test


### PR DESCRIPTION
### What
Adds a GitHub Actions workflow that runs Maven unit tests using Java 17.

### When it runs
- On every pull request
- On pushes to main

### Command
- mvn clean test

### Impact
No production code changes. This only adds CI automation.